### PR TITLE
A Japanese font for the notebook.

### DIFF
--- a/fonts/FONT_LICENSE.yaml
+++ b/fonts/FONT_LICENSE.yaml
@@ -41,3 +41,8 @@
       This font is derived from DroidSansFallback and DroidSansJapanese,
       whose digitized data copyright Google Corporation (c) 2006, 2009
       Droid is a trademark of Google Corp.
+- Kusamochi-Regular.ttf:
+   license: |
+      Copyright: 2020 The Yomogi Project Authors (https://github.com/satsuyako/YomogiFont)
+      License: OFL-1.1
+      Kusamochi is a proportional version of Yomogi Font ver 3.00. (Modified by OOTA, Masato)


### PR DESCRIPTION
A Japanese font for the notebook, Kusamochi is a proportional version of Yomogi Font, which is a handwritingish font.
I mechanically generated Kusamochi from Yomogi Font.

As far as I know, a Japanese handwriting font has fairly large size...

Example
![poi_solomid](https://user-images.githubusercontent.com/22392249/177040658-64d0ae46-6643-47bf-81bb-c50bea814a69.jpg)
