### PR TITLE
Fixed a missing glyph in Kusamochi-Regular.ttf.

### DIFF
--- a/fonts/FONT_LICENSE.yaml
+++ b/fonts/FONT_LICENSE.yaml
@@ -43,6 +43,6 @@
       Droid is a trademark of Google Corp.
 - Kusamochi-Regular.ttf:
    license: |
-      Copyright: 2020 The Yomogi Project Authors (https://github.com/satsuyako/YomogiFont)
+      Copyright: 2020 The Yomogi Project Authors (https://github.com/satsuyako/YomogiFont), all rights reserved.
       License: OFL-1.1
-      Kusamochi is a proportional version of Yomogi Font ver 3.00. (Modified by OOTA, Masato)
+      Kusamochi is a proportional version of Yomogi Font ver 3.205. (Modified by OOTA, Masato)


### PR DESCRIPTION
Seemingly, I deleted U+3000 IDEOGRAPHIC SPACE from the previous version of Kusamochi-Regular.ttf, so I would add it, though I already added a work-around to the Japanese translation of Naev.